### PR TITLE
feat: add validators for basic types, pointers, and struct fields

### DIFF
--- a/bool.go
+++ b/bool.go
@@ -1,0 +1,33 @@
+package validate
+
+// BoolTruef returns a Validator that fails if value is false.
+// The error message is formatted using template and args.
+func BoolTruef[T ~bool](value T, template string, args ...any) ValidatorFunc {
+	return func() error {
+		if !bool(value) {
+			return Errorf(template, args...)
+		}
+		return nil
+	}
+}
+
+// BoolTrue returns a Validator that fails if value is false.
+func BoolTrue[T ~bool](value T) ValidatorFunc {
+	return BoolTruef(value, "must be true")
+}
+
+// BoolFalsef returns a Validator that fails if value is true.
+// The error message is formatted using template and args.
+func BoolFalsef[T ~bool](value T, template string, args ...any) ValidatorFunc {
+	return func() error {
+		if bool(value) {
+			return Errorf(template, args...)
+		}
+		return nil
+	}
+}
+
+// BoolFalse returns a Validator that fails if value is true.
+func BoolFalse[T ~bool](value T) ValidatorFunc {
+	return BoolFalsef(value, "must be false")
+}

--- a/bool_test.go
+++ b/bool_test.go
@@ -1,0 +1,114 @@
+package validate_test
+
+import (
+	"testing"
+
+	"github.com/kyuff/validate"
+	"github.com/kyuff/validate/internal/assert"
+)
+
+func TestBools(t *testing.T) {
+	t.Run("BoolTrue", func(t *testing.T) {
+		t.Run("fail on false value", func(t *testing.T) {
+			// arrange
+			var (
+				value = false
+			)
+
+			// act
+			got := validate.BoolTrue(value).Validate()
+
+			// assert
+			assert.Error(t, got)
+			assert.ErrorIs(t, validate.Error{}, got)
+		})
+
+		t.Run("pass on true value", func(t *testing.T) {
+			// arrange
+			var (
+				value = true
+			)
+
+			// act
+			got := validate.BoolTrue(value).Validate()
+
+			// assert
+			assert.NoError(t, got)
+		})
+
+		t.Run("pass with named bool type", func(t *testing.T) {
+			// arrange
+			type Flag bool
+			var (
+				value = Flag(true)
+			)
+
+			// act
+			got := validate.BoolTrue(value).Validate()
+
+			// assert
+			assert.NoError(t, got)
+		})
+	})
+
+	t.Run("BoolTruef", func(t *testing.T) {
+		t.Run("fail with custom message", func(t *testing.T) {
+			// arrange
+			var (
+				value = false
+			)
+
+			// act
+			got := validate.BoolTruef(value, "must be accepted").Validate()
+
+			// assert
+			assert.Error(t, got)
+			assert.Match(t, "must be accepted", got.Error())
+		})
+	})
+
+	t.Run("BoolFalse", func(t *testing.T) {
+		t.Run("fail on true value", func(t *testing.T) {
+			// arrange
+			var (
+				value = true
+			)
+
+			// act
+			got := validate.BoolFalse(value).Validate()
+
+			// assert
+			assert.Error(t, got)
+			assert.ErrorIs(t, validate.Error{}, got)
+		})
+
+		t.Run("pass on false value", func(t *testing.T) {
+			// arrange
+			var (
+				value = false
+			)
+
+			// act
+			got := validate.BoolFalse(value).Validate()
+
+			// assert
+			assert.NoError(t, got)
+		})
+	})
+
+	t.Run("BoolFalsef", func(t *testing.T) {
+		t.Run("fail with custom message", func(t *testing.T) {
+			// arrange
+			var (
+				value = true
+			)
+
+			// act
+			got := validate.BoolFalsef(value, "must not be set").Validate()
+
+			// assert
+			assert.Error(t, got)
+			assert.Match(t, "must not be set", got.Error())
+		})
+	})
+}

--- a/fields.go
+++ b/fields.go
@@ -6,7 +6,7 @@ import (
 	"sync"
 )
 
-var validatorType = reflect.TypeOf((*Validator)(nil)).Elem()
+var validatorType = reflect.TypeFor[Validator]()
 
 type fieldsStrictEntry struct {
 	err     error

--- a/fields.go
+++ b/fields.go
@@ -1,0 +1,76 @@
+package validate
+
+import (
+	"errors"
+	"reflect"
+	"sync"
+)
+
+var validatorType = reflect.TypeOf((*Validator)(nil)).Elem()
+
+type fieldsStrictEntry struct {
+	err     error
+	indices []int
+}
+
+var fieldsStrictCache sync.Map // map[reflect.Type]*fieldsStrictEntry
+
+func loadFieldsStrictEntry(t reflect.Type) *fieldsStrictEntry {
+	if v, ok := fieldsStrictCache.Load(t); ok {
+		return v.(*fieldsStrictEntry)
+	}
+
+	entry := buildFieldsStrictEntry(t)
+	actual, _ := fieldsStrictCache.LoadOrStore(t, entry)
+	return actual.(*fieldsStrictEntry)
+}
+
+func buildFieldsStrictEntry(t reflect.Type) *fieldsStrictEntry {
+	indices := make([]int, 0, t.NumField())
+	for i := range t.NumField() {
+		field := t.Field(i)
+		if !field.Type.Implements(validatorType) {
+			return &fieldsStrictEntry{
+				err: Errorf("field %s does not implement Validator", field.Name),
+			}
+		}
+		indices = append(indices, i)
+	}
+	return &fieldsStrictEntry{indices: indices}
+}
+
+// FieldsStrict returns a Validator that iterates all fields of a struct and
+// calls Validate() on each one. It fails immediately if any field does not
+// implement the Validator interface, and collects validation errors from all fields.
+// Accepts a struct or a pointer to a struct.
+// Reflection metadata is cached per type, so repeated calls for the same type
+// avoid redundant reflection overhead.
+func FieldsStrict(s any) ValidatorFunc {
+	return func() error {
+		v := reflect.ValueOf(s)
+
+		for v.Kind() == reflect.Ptr {
+			if v.IsNil() {
+				return Errorf("must not be nil")
+			}
+			v = v.Elem()
+		}
+
+		if v.Kind() != reflect.Struct {
+			return Errorf("must be a struct")
+		}
+
+		entry := loadFieldsStrictEntry(v.Type())
+		if entry.err != nil {
+			return entry.err
+		}
+
+		var err error
+		for _, i := range entry.indices {
+			validator := v.Field(i).Interface().(Validator)
+			err = errors.Join(err, validator.Validate())
+		}
+
+		return err
+	}
+}

--- a/fields_test.go
+++ b/fields_test.go
@@ -1,0 +1,196 @@
+package validate_test
+
+import (
+	"testing"
+
+	"github.com/kyuff/validate"
+	"github.com/kyuff/validate/internal/assert"
+)
+
+type fieldName string
+
+func (n fieldName) Validate() error {
+	return validate.StringNotEmpty(n).Validate()
+}
+
+type fieldAddress string
+
+func (a fieldAddress) Validate() error {
+	return validate.StringNotEmpty(a).Validate()
+}
+
+type fieldOrder struct {
+	Name    fieldName
+	Address fieldAddress
+}
+
+type fieldOrderWithInvalidField struct {
+	Name  fieldName
+	Score int
+}
+
+type fieldLargeOrder struct {
+	Name        fieldName
+	Address     fieldAddress
+	City        fieldName
+	Country     fieldName
+	PostalCode  fieldName
+	PhoneNumber fieldName
+	Email       fieldName
+	Notes       fieldAddress
+}
+
+func BenchmarkFieldsStrict(b *testing.B) {
+	b.Run("small struct", func(b *testing.B) {
+		sut := fieldOrder{
+			Name:    "John",
+			Address: "123 Main St",
+		}
+
+		b.ResetTimer()
+		for b.Loop() {
+			_ = validate.FieldsStrict(sut).Validate()
+		}
+	})
+
+	b.Run("large struct", func(b *testing.B) {
+		sut := fieldLargeOrder{
+			Name:        "John",
+			Address:     "123 Main St",
+			City:        "Springfield",
+			Country:     "US",
+			PostalCode:  "12345",
+			PhoneNumber: "555-1234",
+			Email:       "john@example.com",
+			Notes:       "Leave at door",
+		}
+
+		b.ResetTimer()
+		for b.Loop() {
+			_ = validate.FieldsStrict(sut).Validate()
+		}
+	})
+
+	b.Run("pointer to struct", func(b *testing.B) {
+		sut := &fieldOrder{
+			Name:    "John",
+			Address: "123 Main St",
+		}
+
+		b.ResetTimer()
+		for b.Loop() {
+			_ = validate.FieldsStrict(sut).Validate()
+		}
+	})
+}
+
+func TestFieldsStrict(t *testing.T) {
+	t.Run("fail when a field does not implement Validator", func(t *testing.T) {
+		// arrange
+		var (
+			sut = fieldOrderWithInvalidField{
+				Name:  "John",
+				Score: 10,
+			}
+		)
+
+		// act
+		got := validate.FieldsStrict(sut).Validate()
+
+		// assert
+		assert.Error(t, got)
+		assert.ErrorIs(t, validate.Error{}, got)
+	})
+
+	t.Run("fail when a field is invalid", func(t *testing.T) {
+		// arrange
+		var (
+			sut = fieldOrder{
+				Name:    "",
+				Address: "123 Main St",
+			}
+		)
+
+		// act
+		got := validate.FieldsStrict(sut).Validate()
+
+		// assert
+		assert.Error(t, got)
+	})
+
+	t.Run("fail when multiple fields are invalid", func(t *testing.T) {
+		// arrange
+		var (
+			sut = fieldOrder{
+				Name:    "",
+				Address: "",
+			}
+		)
+
+		// act
+		got := validate.FieldsStrict(sut).Validate()
+
+		// assert
+		assert.Error(t, got)
+	})
+
+	t.Run("fail on nil pointer", func(t *testing.T) {
+		// arrange
+		var (
+			sut *fieldOrder = nil
+		)
+
+		// act
+		got := validate.FieldsStrict(sut).Validate()
+
+		// assert
+		assert.Error(t, got)
+		assert.ErrorIs(t, validate.Error{}, got)
+	})
+
+	t.Run("fail on non-struct input", func(t *testing.T) {
+		// arrange
+		var (
+			sut = "not a struct"
+		)
+
+		// act
+		got := validate.FieldsStrict(sut).Validate()
+
+		// assert
+		assert.Error(t, got)
+		assert.ErrorIs(t, validate.Error{}, got)
+	})
+
+	t.Run("pass when all fields are valid", func(t *testing.T) {
+		// arrange
+		var (
+			sut = fieldOrder{
+				Name:    "John",
+				Address: "123 Main St",
+			}
+		)
+
+		// act
+		got := validate.FieldsStrict(sut).Validate()
+
+		// assert
+		assert.NoError(t, got)
+	})
+
+	t.Run("pass when given a pointer to a valid struct", func(t *testing.T) {
+		// arrange
+		var (
+			sut = &fieldOrder{
+				Name:    "John",
+				Address: "123 Main St",
+			}
+		)
+
+		// act
+		got := validate.FieldsStrict(sut).Validate()
+
+		// assert
+		assert.NoError(t, got)
+	})
+}

--- a/nil.go
+++ b/nil.go
@@ -1,0 +1,30 @@
+package validate
+
+// NotNilf returns a Validator that fails if value is nil.
+// If non-nil, it calls Validate() on the pointed-to value.
+// The nil error message is formatted using template and args.
+func NotNilf[T Validator](value *T, template string, args ...any) ValidatorFunc {
+	return func() error {
+		if value == nil {
+			return Errorf(template, args...)
+		}
+		return (*value).Validate()
+	}
+}
+
+// NotNil returns a Validator that fails if value is nil.
+// If non-nil, it calls Validate() on the pointed-to value.
+func NotNil[T Validator](value *T) ValidatorFunc {
+	return NotNilf(value, "is required")
+}
+
+// IfNotNil returns a Validator that passes when value is nil.
+// If non-nil, it calls Validate() on the pointed-to value.
+func IfNotNil[T Validator](value *T) ValidatorFunc {
+	return func() error {
+		if value == nil {
+			return nil
+		}
+		return (*value).Validate()
+	}
+}

--- a/nil_test.go
+++ b/nil_test.go
@@ -1,0 +1,117 @@
+package validate_test
+
+import (
+	"testing"
+
+	"github.com/kyuff/validate"
+	"github.com/kyuff/validate/internal/assert"
+)
+
+type nilTestID string
+
+func (id nilTestID) Validate() error {
+	return validate.StringNotEmpty(id).Validate()
+}
+
+func TestNil(t *testing.T) {
+	newID := func(s string) *nilTestID { v := nilTestID(s); return &v }
+
+	t.Run("NotNil", func(t *testing.T) {
+		t.Run("fail on nil", func(t *testing.T) {
+			// arrange
+			var (
+				value *nilTestID = nil
+			)
+
+			// act
+			got := validate.NotNil(value).Validate()
+
+			// assert
+			assert.Error(t, got)
+			assert.ErrorIs(t, validate.Error{}, got)
+		})
+
+		t.Run("fail when pointed-to value is invalid", func(t *testing.T) {
+			// arrange
+			var (
+				value = newID("")
+			)
+
+			// act
+			got := validate.NotNil(value).Validate()
+
+			// assert
+			assert.Error(t, got)
+		})
+
+		t.Run("pass when non-nil and valid", func(t *testing.T) {
+			// arrange
+			var (
+				value = newID("abc")
+			)
+
+			// act
+			got := validate.NotNil(value).Validate()
+
+			// assert
+			assert.NoError(t, got)
+		})
+	})
+
+	t.Run("NotNilf", func(t *testing.T) {
+		t.Run("fail with custom message on nil", func(t *testing.T) {
+			// arrange
+			var (
+				value *nilTestID = nil
+			)
+
+			// act
+			got := validate.NotNilf(value, "user is required").Validate()
+
+			// assert
+			assert.Error(t, got)
+			assert.Match(t, "user is required", got.Error())
+		})
+	})
+
+	t.Run("IfNotNil", func(t *testing.T) {
+		t.Run("pass on nil", func(t *testing.T) {
+			// arrange
+			var (
+				value *nilTestID = nil
+			)
+
+			// act
+			got := validate.IfNotNil(value).Validate()
+
+			// assert
+			assert.NoError(t, got)
+		})
+
+		t.Run("fail when pointed-to value is invalid", func(t *testing.T) {
+			// arrange
+			var (
+				value = newID("")
+			)
+
+			// act
+			got := validate.IfNotNil(value).Validate()
+
+			// assert
+			assert.Error(t, got)
+		})
+
+		t.Run("pass when non-nil and valid", func(t *testing.T) {
+			// arrange
+			var (
+				value = newID("abc")
+			)
+
+			// act
+			got := validate.IfNotNil(value).Validate()
+
+			// assert
+			assert.NoError(t, got)
+		})
+	})
+}

--- a/number.go
+++ b/number.go
@@ -1,0 +1,93 @@
+package validate
+
+type integer interface {
+	~int | ~int8 | ~int16 | ~int32 | ~int64 | ~uint | ~uint8 | ~uint16 | ~uint32 | ~uint64 | ~uintptr
+}
+
+type float interface {
+	~float32 | ~float64
+}
+
+type number interface {
+	integer | float
+}
+
+// NumberMinf returns a Validator that fails if value is less than min.
+// The error message is formatted using template and args.
+func NumberMinf[T number](value, min T, template string, args ...any) ValidatorFunc {
+	return func() error {
+		if value < min {
+			return Errorf(template, args...)
+		}
+		return nil
+	}
+}
+
+// NumberMin returns a Validator that fails if value is less than min.
+func NumberMin[T number](value, min T) ValidatorFunc {
+	return NumberMinf(value, min, "must be at least %v", min)
+}
+
+// NumberMaxf returns a Validator that fails if value is greater than max.
+// The error message is formatted using template and args.
+func NumberMaxf[T number](value, max T, template string, args ...any) ValidatorFunc {
+	return func() error {
+		if value > max {
+			return Errorf(template, args...)
+		}
+		return nil
+	}
+}
+
+// NumberMax returns a Validator that fails if value is greater than max.
+func NumberMax[T number](value, max T) ValidatorFunc {
+	return NumberMaxf(value, max, "must be at most %v", max)
+}
+
+// NumberPositivef returns a Validator that fails if value is zero or negative.
+// The error message is formatted using template and args.
+func NumberPositivef[T number](value T, template string, args ...any) ValidatorFunc {
+	return func() error {
+		if value <= 0 {
+			return Errorf(template, args...)
+		}
+		return nil
+	}
+}
+
+// NumberPositive returns a Validator that fails if value is zero or negative.
+func NumberPositive[T number](value T) ValidatorFunc {
+	return NumberPositivef(value, "must be positive")
+}
+
+// NumberNegativef returns a Validator that fails if value is zero or positive.
+// The error message is formatted using template and args.
+func NumberNegativef[T number](value T, template string, args ...any) ValidatorFunc {
+	return func() error {
+		if value >= 0 {
+			return Errorf(template, args...)
+		}
+		return nil
+	}
+}
+
+// NumberNegative returns a Validator that fails if value is zero or positive.
+func NumberNegative[T number](value T) ValidatorFunc {
+	return NumberNegativef(value, "must be negative")
+}
+
+// NumberBetweenf returns a Validator that fails if value is outside the inclusive range [min, max].
+// The error message is formatted using template and args.
+func NumberBetweenf[T number](value, min, max T, template string, args ...any) ValidatorFunc {
+	return func() error {
+		if value < min || value > max {
+			return Errorf(template, args...)
+		}
+		return nil
+	}
+}
+
+// NumberBetween returns a Validator that fails if value is outside the inclusive range [min, max].
+func NumberBetween[T number](value, min, max T) ValidatorFunc {
+	return NumberBetweenf(value, min, max, "must be between %v and %v", min, max)
+}

--- a/number_test.go
+++ b/number_test.go
@@ -1,0 +1,374 @@
+package validate_test
+
+import (
+	"testing"
+
+	"github.com/kyuff/validate"
+	"github.com/kyuff/validate/internal/assert"
+)
+
+func TestNumbers(t *testing.T) {
+	t.Run("NumberMin", func(t *testing.T) {
+		t.Run("fail below minimum", func(t *testing.T) {
+			// arrange
+			var (
+				value = 3
+				min   = 5
+			)
+
+			// act
+			got := validate.NumberMin(value, min).Validate()
+
+			// assert
+			assert.Error(t, got)
+			assert.ErrorIs(t, validate.Error{}, got)
+		})
+
+		t.Run("pass at exact minimum", func(t *testing.T) {
+			// arrange
+			var (
+				value = 5
+				min   = 5
+			)
+
+			// act
+			got := validate.NumberMin(value, min).Validate()
+
+			// assert
+			assert.NoError(t, got)
+		})
+
+		t.Run("pass above minimum", func(t *testing.T) {
+			// arrange
+			var (
+				value = 10
+				min   = 5
+			)
+
+			// act
+			got := validate.NumberMin(value, min).Validate()
+
+			// assert
+			assert.NoError(t, got)
+		})
+
+		t.Run("pass with float type", func(t *testing.T) {
+			// arrange
+			var (
+				value = 3.14
+				min   = 2.0
+			)
+
+			// act
+			got := validate.NumberMin(value, min).Validate()
+
+			// assert
+			assert.NoError(t, got)
+		})
+
+		t.Run("pass with named int type", func(t *testing.T) {
+			// arrange
+			type Count int
+			var (
+				value = Count(10)
+				min   = Count(5)
+			)
+
+			// act
+			got := validate.NumberMin(value, min).Validate()
+
+			// assert
+			assert.NoError(t, got)
+		})
+	})
+
+	t.Run("NumberMinf", func(t *testing.T) {
+		t.Run("fail with custom message", func(t *testing.T) {
+			// arrange
+			var (
+				value = 3
+			)
+
+			// act
+			got := validate.NumberMinf(value, 5, "count too low").Validate()
+
+			// assert
+			assert.Error(t, got)
+			assert.Match(t, "count too low", got.Error())
+		})
+	})
+
+	t.Run("NumberMax", func(t *testing.T) {
+		t.Run("fail above maximum", func(t *testing.T) {
+			// arrange
+			var (
+				value = 15
+				max   = 10
+			)
+
+			// act
+			got := validate.NumberMax(value, max).Validate()
+
+			// assert
+			assert.Error(t, got)
+			assert.ErrorIs(t, validate.Error{}, got)
+		})
+
+		t.Run("pass at exact maximum", func(t *testing.T) {
+			// arrange
+			var (
+				value = 10
+				max   = 10
+			)
+
+			// act
+			got := validate.NumberMax(value, max).Validate()
+
+			// assert
+			assert.NoError(t, got)
+		})
+
+		t.Run("pass below maximum", func(t *testing.T) {
+			// arrange
+			var (
+				value = 5
+				max   = 10
+			)
+
+			// act
+			got := validate.NumberMax(value, max).Validate()
+
+			// assert
+			assert.NoError(t, got)
+		})
+	})
+
+	t.Run("NumberMaxf", func(t *testing.T) {
+		t.Run("fail with custom message", func(t *testing.T) {
+			// arrange
+			var (
+				value = 15
+			)
+
+			// act
+			got := validate.NumberMaxf(value, 10, "count too high").Validate()
+
+			// assert
+			assert.Error(t, got)
+			assert.Match(t, "count too high", got.Error())
+		})
+	})
+
+	t.Run("NumberPositive", func(t *testing.T) {
+		t.Run("fail on zero", func(t *testing.T) {
+			// arrange
+			var (
+				value = 0
+			)
+
+			// act
+			got := validate.NumberPositive(value).Validate()
+
+			// assert
+			assert.Error(t, got)
+			assert.ErrorIs(t, validate.Error{}, got)
+		})
+
+		t.Run("fail on negative value", func(t *testing.T) {
+			// arrange
+			var (
+				value = -1
+			)
+
+			// act
+			got := validate.NumberPositive(value).Validate()
+
+			// assert
+			assert.Error(t, got)
+			assert.ErrorIs(t, validate.Error{}, got)
+		})
+
+		t.Run("pass on positive value", func(t *testing.T) {
+			// arrange
+			var (
+				value = 5
+			)
+
+			// act
+			got := validate.NumberPositive(value).Validate()
+
+			// assert
+			assert.NoError(t, got)
+		})
+	})
+
+	t.Run("NumberPositivef", func(t *testing.T) {
+		t.Run("fail with custom message", func(t *testing.T) {
+			// arrange
+			var (
+				value = 0
+			)
+
+			// act
+			got := validate.NumberPositivef(value, "must be greater than zero").Validate()
+
+			// assert
+			assert.Error(t, got)
+			assert.Match(t, "must be greater than zero", got.Error())
+		})
+	})
+
+	t.Run("NumberNegative", func(t *testing.T) {
+		t.Run("fail on zero", func(t *testing.T) {
+			// arrange
+			var (
+				value = 0
+			)
+
+			// act
+			got := validate.NumberNegative(value).Validate()
+
+			// assert
+			assert.Error(t, got)
+			assert.ErrorIs(t, validate.Error{}, got)
+		})
+
+		t.Run("fail on positive value", func(t *testing.T) {
+			// arrange
+			var (
+				value = 1
+			)
+
+			// act
+			got := validate.NumberNegative(value).Validate()
+
+			// assert
+			assert.Error(t, got)
+			assert.ErrorIs(t, validate.Error{}, got)
+		})
+
+		t.Run("pass on negative value", func(t *testing.T) {
+			// arrange
+			var (
+				value = -5
+			)
+
+			// act
+			got := validate.NumberNegative(value).Validate()
+
+			// assert
+			assert.NoError(t, got)
+		})
+	})
+
+	t.Run("NumberNegativef", func(t *testing.T) {
+		t.Run("fail with custom message", func(t *testing.T) {
+			// arrange
+			var (
+				value = 0
+			)
+
+			// act
+			got := validate.NumberNegativef(value, "must be less than zero").Validate()
+
+			// assert
+			assert.Error(t, got)
+			assert.Match(t, "must be less than zero", got.Error())
+		})
+	})
+
+	t.Run("NumberBetween", func(t *testing.T) {
+		t.Run("fail below range", func(t *testing.T) {
+			// arrange
+			var (
+				value = 0
+				min   = 1
+				max   = 10
+			)
+
+			// act
+			got := validate.NumberBetween(value, min, max).Validate()
+
+			// assert
+			assert.Error(t, got)
+			assert.ErrorIs(t, validate.Error{}, got)
+		})
+
+		t.Run("fail above range", func(t *testing.T) {
+			// arrange
+			var (
+				value = 11
+				min   = 1
+				max   = 10
+			)
+
+			// act
+			got := validate.NumberBetween(value, min, max).Validate()
+
+			// assert
+			assert.Error(t, got)
+			assert.ErrorIs(t, validate.Error{}, got)
+		})
+
+		t.Run("pass at minimum boundary", func(t *testing.T) {
+			// arrange
+			var (
+				value = 1
+				min   = 1
+				max   = 10
+			)
+
+			// act
+			got := validate.NumberBetween(value, min, max).Validate()
+
+			// assert
+			assert.NoError(t, got)
+		})
+
+		t.Run("pass at maximum boundary", func(t *testing.T) {
+			// arrange
+			var (
+				value = 10
+				min   = 1
+				max   = 10
+			)
+
+			// act
+			got := validate.NumberBetween(value, min, max).Validate()
+
+			// assert
+			assert.NoError(t, got)
+		})
+
+		t.Run("pass within range", func(t *testing.T) {
+			// arrange
+			var (
+				value = 5
+				min   = 1
+				max   = 10
+			)
+
+			// act
+			got := validate.NumberBetween(value, min, max).Validate()
+
+			// assert
+			assert.NoError(t, got)
+		})
+	})
+
+	t.Run("NumberBetweenf", func(t *testing.T) {
+		t.Run("fail with custom message", func(t *testing.T) {
+			// arrange
+			var (
+				value = 0
+			)
+
+			// act
+			got := validate.NumberBetweenf(value, 1, 10, "out of range").Validate()
+
+			// assert
+			assert.Error(t, got)
+			assert.Match(t, "out of range", got.Error())
+		})
+	})
+}

--- a/required.go
+++ b/required.go
@@ -1,0 +1,20 @@
+package validate
+
+// Requiredf returns a Validator that fails if value equals its zero value.
+// Works with any comparable type, including named types such as type ID string.
+// The error message is formatted using template and args.
+func Requiredf[T comparable](value T, template string, args ...any) ValidatorFunc {
+	return func() error {
+		var zero T
+		if value == zero {
+			return Errorf(template, args...)
+		}
+		return nil
+	}
+}
+
+// Required returns a Validator that fails if value equals its zero value.
+// Works with any comparable type, including named types such as type ID string.
+func Required[T comparable](value T) ValidatorFunc {
+	return Requiredf(value, "is required")
+}

--- a/required_test.go
+++ b/required_test.go
@@ -1,0 +1,125 @@
+package validate_test
+
+import (
+	"testing"
+
+	"github.com/kyuff/validate"
+	"github.com/kyuff/validate/internal/assert"
+)
+
+func TestRequired(t *testing.T) {
+	t.Run("Required", func(t *testing.T) {
+		t.Run("fail on zero string", func(t *testing.T) {
+			// arrange
+			var (
+				value = ""
+			)
+
+			// act
+			got := validate.Required(value).Validate()
+
+			// assert
+			assert.Error(t, got)
+			assert.ErrorIs(t, validate.Error{}, got)
+		})
+
+		t.Run("fail on zero int", func(t *testing.T) {
+			// arrange
+			var (
+				value = 0
+			)
+
+			// act
+			got := validate.Required(value).Validate()
+
+			// assert
+			assert.Error(t, got)
+			assert.ErrorIs(t, validate.Error{}, got)
+		})
+
+		t.Run("fail on zero bool", func(t *testing.T) {
+			// arrange
+			var (
+				value = false
+			)
+
+			// act
+			got := validate.Required(value).Validate()
+
+			// assert
+			assert.Error(t, got)
+			assert.ErrorIs(t, validate.Error{}, got)
+		})
+
+		t.Run("pass on non-zero string", func(t *testing.T) {
+			// arrange
+			var (
+				value = "hello"
+			)
+
+			// act
+			got := validate.Required(value).Validate()
+
+			// assert
+			assert.NoError(t, got)
+		})
+
+		t.Run("pass on non-zero int", func(t *testing.T) {
+			// arrange
+			var (
+				value = 42
+			)
+
+			// act
+			got := validate.Required(value).Validate()
+
+			// assert
+			assert.NoError(t, got)
+		})
+
+		t.Run("pass with named string type", func(t *testing.T) {
+			// arrange
+			type ID string
+			var (
+				value = ID("abc")
+			)
+
+			// act
+			got := validate.Required(value).Validate()
+
+			// assert
+			assert.NoError(t, got)
+		})
+
+		t.Run("fail with named string type at zero value", func(t *testing.T) {
+			// arrange
+			type ID string
+			var (
+				value = ID("")
+			)
+
+			// act
+			got := validate.Required(value).Validate()
+
+			// assert
+			assert.Error(t, got)
+			assert.ErrorIs(t, validate.Error{}, got)
+		})
+	})
+
+	t.Run("Requiredf", func(t *testing.T) {
+		t.Run("fail with custom message", func(t *testing.T) {
+			// arrange
+			var (
+				value = ""
+			)
+
+			// act
+			got := validate.Requiredf(value, "user id is required").Validate()
+
+			// assert
+			assert.Error(t, got)
+			assert.Match(t, "user id is required", got.Error())
+		})
+	})
+}

--- a/string.go
+++ b/string.go
@@ -1,6 +1,9 @@
 package validate
 
-import "regexp"
+import (
+	"regexp"
+	"slices"
+)
 
 // StringNotEmptyf returns a Validator that fails if value is an empty string.
 // The error message is formatted using template and args.
@@ -70,10 +73,8 @@ func StringMatches[T ~string](value T, pattern *regexp.Regexp) ValidatorFunc {
 // The error message is formatted using template and args.
 func StringOneOff[T ~string](value T, options []T, template string, args ...any) ValidatorFunc {
 	return func() error {
-		for _, o := range options {
-			if value == o {
-				return nil
-			}
+		if slices.Contains(options, value) {
+			return nil
 		}
 		return Errorf(template, args...)
 	}

--- a/string.go
+++ b/string.go
@@ -2,6 +2,8 @@ package validate
 
 import "regexp"
 
+// StringNotEmptyf returns a Validator that fails if value is an empty string.
+// The error message is formatted using template and args.
 func StringNotEmptyf[T ~string](value T, template string, args ...any) ValidatorFunc {
 	return func() error {
 		if value == "" {
@@ -11,10 +13,13 @@ func StringNotEmptyf[T ~string](value T, template string, args ...any) Validator
 	}
 }
 
+// StringNotEmpty returns a Validator that fails if value is an empty string.
 func StringNotEmpty[T ~string](value T) ValidatorFunc {
 	return StringNotEmptyf(value, "must not be empty")
 }
 
+// StringMinLengthf returns a Validator that fails if value has fewer than min bytes.
+// The error message is formatted using template and args.
 func StringMinLengthf[T ~string](value T, min int, template string, args ...any) ValidatorFunc {
 	return func() error {
 		if len(value) < min {
@@ -24,10 +29,13 @@ func StringMinLengthf[T ~string](value T, min int, template string, args ...any)
 	}
 }
 
+// StringMinLength returns a Validator that fails if value has fewer than min bytes.
 func StringMinLength[T ~string](value T, min int) ValidatorFunc {
 	return StringMinLengthf(value, min, "must be at least %d characters", min)
 }
 
+// StringMaxLengthf returns a Validator that fails if value exceeds max bytes.
+// The error message is formatted using template and args.
 func StringMaxLengthf[T ~string](value T, max int, template string, args ...any) ValidatorFunc {
 	return func() error {
 		if len(value) > max {
@@ -37,10 +45,13 @@ func StringMaxLengthf[T ~string](value T, max int, template string, args ...any)
 	}
 }
 
+// StringMaxLength returns a Validator that fails if value exceeds max bytes.
 func StringMaxLength[T ~string](value T, max int) ValidatorFunc {
 	return StringMaxLengthf(value, max, "must be at most %d characters", max)
 }
 
+// StringMatchesf returns a Validator that fails if value does not match pattern.
+// The error message is formatted using template and args.
 func StringMatchesf[T ~string](value T, pattern *regexp.Regexp, template string, args ...any) ValidatorFunc {
 	return func() error {
 		if !pattern.MatchString(string(value)) {
@@ -50,10 +61,13 @@ func StringMatchesf[T ~string](value T, pattern *regexp.Regexp, template string,
 	}
 }
 
+// StringMatches returns a Validator that fails if value does not match pattern.
 func StringMatches[T ~string](value T, pattern *regexp.Regexp) ValidatorFunc {
 	return StringMatchesf(value, pattern, "must match %v", pattern)
 }
 
+// StringOneOff returns a Validator that fails if value is not present in options.
+// The error message is formatted using template and args.
 func StringOneOff[T ~string](value T, options []T, template string, args ...any) ValidatorFunc {
 	return func() error {
 		for _, o := range options {
@@ -65,6 +79,7 @@ func StringOneOff[T ~string](value T, options []T, template string, args ...any)
 	}
 }
 
+// StringOneOf returns a Validator that fails if value is not present in options.
 func StringOneOf[T ~string](value T, options ...T) ValidatorFunc {
 	return StringOneOff(value, options, "%v must be one of %v", value, options)
 }

--- a/string.go
+++ b/string.go
@@ -1,0 +1,70 @@
+package validate
+
+import "regexp"
+
+func StringNotEmptyf[T ~string](value T, template string, args ...any) ValidatorFunc {
+	return func() error {
+		if value == "" {
+			return Errorf(template, args...)
+		}
+		return nil
+	}
+}
+
+func StringNotEmpty[T ~string](value T) ValidatorFunc {
+	return StringNotEmptyf(value, "must not be empty")
+}
+
+func StringMinLengthf[T ~string](value T, min int, template string, args ...any) ValidatorFunc {
+	return func() error {
+		if len(value) < min {
+			return Errorf(template, args...)
+		}
+		return nil
+	}
+}
+
+func StringMinLength[T ~string](value T, min int) ValidatorFunc {
+	return StringMinLengthf(value, min, "must be at least %d characters", min)
+}
+
+func StringMaxLengthf[T ~string](value T, max int, template string, args ...any) ValidatorFunc {
+	return func() error {
+		if len(value) > max {
+			return Errorf(template, args...)
+		}
+		return nil
+	}
+}
+
+func StringMaxLength[T ~string](value T, max int) ValidatorFunc {
+	return StringMaxLengthf(value, max, "must be at most %d characters", max)
+}
+
+func StringMatchesf[T ~string](value T, pattern *regexp.Regexp, template string, args ...any) ValidatorFunc {
+	return func() error {
+		if !pattern.MatchString(string(value)) {
+			return Errorf(template, args...)
+		}
+		return nil
+	}
+}
+
+func StringMatches[T ~string](value T, pattern *regexp.Regexp) ValidatorFunc {
+	return StringMatchesf(value, pattern, "must match %v", pattern)
+}
+
+func StringOneOff[T ~string](value T, options []T, template string, args ...any) ValidatorFunc {
+	return func() error {
+		for _, o := range options {
+			if value == o {
+				return nil
+			}
+		}
+		return Errorf(template, args...)
+	}
+}
+
+func StringOneOf[T ~string](value T, options ...T) ValidatorFunc {
+	return StringOneOff(value, options, "%v must be one of %v", value, options)
+}

--- a/string_test.go
+++ b/string_test.go
@@ -1,0 +1,301 @@
+package validate_test
+
+import (
+	"regexp"
+	"testing"
+
+	"github.com/kyuff/validate"
+	"github.com/kyuff/validate/internal/assert"
+)
+
+func TestStrings(t *testing.T) {
+	t.Run("StringNotEmpty", func(t *testing.T) {
+		t.Run("fail on empty string", func(t *testing.T) {
+			// arrange
+			var (
+				value = ""
+			)
+
+			// act
+			got := validate.StringNotEmpty(value).Validate()
+
+			// assert
+			assert.Error(t, got)
+			assert.ErrorIs(t, validate.Error{}, got)
+		})
+
+		t.Run("pass on non-empty string", func(t *testing.T) {
+			// arrange
+			var (
+				value = "hello"
+			)
+
+			// act
+			got := validate.StringNotEmpty(value).Validate()
+
+			// assert
+			assert.NoError(t, got)
+		})
+	})
+
+	t.Run("StringNotEmptyf", func(t *testing.T) {
+		t.Run("fail with custom message", func(t *testing.T) {
+			// arrange
+			var (
+				value = ""
+			)
+
+			// act
+			got := validate.StringNotEmptyf(value, "id is required").Validate()
+
+			// assert
+			assert.Error(t, got)
+			assert.Match(t, "id is required", got.Error())
+		})
+
+		t.Run("pass on non-empty string", func(t *testing.T) {
+			// arrange
+			var (
+				value = "hello"
+			)
+
+			// act
+			got := validate.StringNotEmptyf(value, "id is required").Validate()
+
+			// assert
+			assert.NoError(t, got)
+		})
+	})
+
+	t.Run("StringMinLength", func(t *testing.T) {
+		t.Run("fail below minimum length", func(t *testing.T) {
+			// arrange
+			var (
+				value = "hi"
+				min   = 5
+			)
+
+			// act
+			got := validate.StringMinLength(value, min).Validate()
+
+			// assert
+			assert.Error(t, got)
+			assert.ErrorIs(t, validate.Error{}, got)
+		})
+
+		t.Run("pass at exact minimum length", func(t *testing.T) {
+			// arrange
+			var (
+				value = "abc"
+				min   = len(value)
+			)
+
+			// act
+			got := validate.StringMinLength(value, min).Validate()
+
+			// assert
+			assert.NoError(t, got)
+		})
+
+		t.Run("pass above minimum length", func(t *testing.T) {
+			// arrange
+			var (
+				value = "hello"
+				min   = 3
+			)
+
+			// act
+			got := validate.StringMinLength(value, min).Validate()
+
+			// assert
+			assert.NoError(t, got)
+		})
+	})
+
+	t.Run("StringMinLengthf", func(t *testing.T) {
+		t.Run("fail with custom message", func(t *testing.T) {
+			// arrange
+			var (
+				value = "hi"
+			)
+
+			// act
+			got := validate.StringMinLengthf(value, 5, "too short").Validate()
+
+			// assert
+			assert.Error(t, got)
+			assert.Match(t, "too short", got.Error())
+		})
+	})
+
+	t.Run("StringMaxLength", func(t *testing.T) {
+		t.Run("fail above maximum length", func(t *testing.T) {
+			// arrange
+			var (
+				value = "hello world"
+				max   = 5
+			)
+
+			// act
+			got := validate.StringMaxLength(value, max).Validate()
+
+			// assert
+			assert.Error(t, got)
+			assert.ErrorIs(t, validate.Error{}, got)
+		})
+
+		t.Run("pass at exact maximum length", func(t *testing.T) {
+			// arrange
+			var (
+				value = "abc"
+				max   = len(value)
+			)
+
+			// act
+			got := validate.StringMaxLength(value, max).Validate()
+
+			// assert
+			assert.NoError(t, got)
+		})
+
+		t.Run("pass below maximum length", func(t *testing.T) {
+			// arrange
+			var (
+				value = "hello"
+				max   = 10
+			)
+
+			// act
+			got := validate.StringMaxLength(value, max).Validate()
+
+			// assert
+			assert.NoError(t, got)
+		})
+	})
+
+	t.Run("StringMaxLengthf", func(t *testing.T) {
+		t.Run("fail with custom message", func(t *testing.T) {
+			// arrange
+			var (
+				value = "hello world"
+			)
+
+			// act
+			got := validate.StringMaxLengthf(value, 5, "too long").Validate()
+
+			// assert
+			assert.Error(t, got)
+			assert.Match(t, "too long", got.Error())
+		})
+	})
+
+	t.Run("StringMatches", func(t *testing.T) {
+		t.Run("fail when pattern does not match", func(t *testing.T) {
+			// arrange
+			var (
+				value   = "HELLO"
+				pattern = regexp.MustCompile(`^[a-z]+$`)
+			)
+
+			// act
+			got := validate.StringMatches(value, pattern).Validate()
+
+			// assert
+			assert.Error(t, got)
+			assert.ErrorIs(t, validate.Error{}, got)
+		})
+
+		t.Run("pass when pattern matches", func(t *testing.T) {
+			// arrange
+			var (
+				value   = "hello123"
+				pattern = regexp.MustCompile(`^[a-z0-9]+$`)
+			)
+
+			// act
+			got := validate.StringMatches(value, pattern).Validate()
+
+			// assert
+			assert.NoError(t, got)
+		})
+	})
+
+	t.Run("StringMatchesf", func(t *testing.T) {
+		t.Run("fail with custom message", func(t *testing.T) {
+			// arrange
+			var (
+				value   = "HELLO"
+				pattern = regexp.MustCompile(`^[a-z]+$`)
+			)
+
+			// act
+			got := validate.StringMatchesf(value, pattern, "invalid format").Validate()
+
+			// assert
+			assert.Error(t, got)
+			assert.Match(t, "invalid format", got.Error())
+		})
+	})
+
+	t.Run("StringOneOf", func(t *testing.T) {
+		t.Run("fail when value not in options", func(t *testing.T) {
+			// arrange
+			var (
+				value   = "deleted"
+				options = []string{"active", "inactive"}
+			)
+
+			// act
+			got := validate.StringOneOf(value, options...).Validate()
+
+			// assert
+			assert.Error(t, got)
+			assert.ErrorIs(t, validate.Error{}, got)
+		})
+
+		t.Run("pass when value in options", func(t *testing.T) {
+			// arrange
+			var (
+				value   = "active"
+				options = []string{"active", "inactive", "pending"}
+			)
+
+			// act
+			got := validate.StringOneOf(value, options...).Validate()
+
+			// assert
+			assert.NoError(t, got)
+		})
+	})
+
+	t.Run("StringOneOff", func(t *testing.T) {
+		t.Run("fail with custom message", func(t *testing.T) {
+			// arrange
+			var (
+				value   = "deleted"
+				options = []string{"active", "inactive"}
+			)
+
+			// act
+			got := validate.StringOneOff(value, options, "unknown status").Validate()
+
+			// assert
+			assert.Error(t, got)
+			assert.Match(t, "unknown status", got.Error())
+		})
+
+		t.Run("pass when value in options", func(t *testing.T) {
+			// arrange
+			var (
+				value   = "active"
+				options = []string{"active", "inactive"}
+			)
+
+			// act
+			got := validate.StringOneOff(value, options, "unknown status").Validate()
+
+			// assert
+			assert.NoError(t, got)
+		})
+	})
+}


### PR DESCRIPTION
## Summary

- Add string validators: `StringNotEmpty`, `StringMinLength`, `StringMaxLength`, `StringMatches`, `StringOneOf` (each with an `f` variant for custom error messages)
- Add number validators: `NumberMin`, `NumberMax`, `NumberPositive`, `NumberNegative`, `NumberBetween` (each with an `f` variant)
- Add bool validators: `BoolTrue`, `BoolFalse` (each with an `f` variant)
- Add `Required[T comparable]` / `Requiredf` — zero-value check for any named type
- Add `NotNil[T Validator]` / `NotNilf` — pointer must be non-nil, then validates the pointed-to value
- Add `IfNotNil[T Validator]` — nil passes, non-nil validates the pointed-to value
- Add `FieldsStrict` — validates all fields of a struct, fails if any field does not implement `Validator`; reflection metadata is cached per type for hot-path performance

All validators return `ValidatorFunc` so they compose directly with `validate.All(...)`.

## Design notes

All validators follow the same pattern: the `f` variant holds the logic and accepts a custom error message; the plain variant calls it with a sensible default.

`FieldsStrict` uses a `sync.Map` cache keyed by `reflect.Type` to avoid repeated `Implements` checks on subsequent calls for the same type:

| Case                    | Before  | After  | Speedup     |
|-------------------------|---------|--------|-------------|
| small struct (2 fields) | 85 ns   | 21 ns  | 4× faster   |
| large struct (8 fields) | 288 ns  | 83 ns  | 3.5× faster |
| pointer to struct       | 107 ns  | 46 ns  | 2.3× faster |

## Test plan

- [x] Each validator type has a `TestXxx` function grouped by file (`TestStrings`, `TestNumbers`, `TestBools`, `TestRequired`, `TestNil`, `TestFieldsStrict`)
- [x] All tests pass with `-race`: `go test ./... -count 1 -race`
- [x] Benchmarks verified: `go test -bench BenchmarkFieldsStrict -benchmem`