### PR TITLE
fix(readme): use named types in FieldsStrict example

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,16 +112,20 @@ err := validate.SliceContainsf(roles, "admin", "user must have the admin role")
 `FieldsStrict` validates a struct by calling `Validate()` on every field. All fields must implement `Validator`; the function fails immediately if one does not.
 
 ```go
-type Address struct {
-    Street validate.ValidatorFunc
-    City   validate.ValidatorFunc
+type Street string
+type City string
+
+func (s Street) Validate() error {
+    return validate.StringNotEmpty(s)()
 }
 
-func NewAddress(street, city string) Address {
-    return Address{
-        Street: validate.StringNotEmpty(street),
-        City:   validate.StringNotEmpty(city),
-    }
+func (c City) Validate() error {
+    return validate.StringNotEmpty(c)()
+}
+
+type Address struct {
+    Street Street
+    City   City
 }
 
 func (a Address) Validate() error {


### PR DESCRIPTION
## Summary
- Fixes the `FieldsStrict` code example where `Street` and `City` fields were incorrectly typed as `validate.ValidatorFunc`
- Replaces them with proper named types (`type Street string`, `type City string`) that each implement `Validator`, which is the actual pattern `FieldsStrict` is designed for

## Test plan
- [ ] Verify the example reads correctly in the rendered README